### PR TITLE
Issue # 5 rocksdb.WriteBatchWithIndex.remove(byte[]) fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>spark-streaming-sql-s3-connector</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <packaging>jar</packaging>
   <name>Spark Structure Streaming S3 Connector</name>
 

--- a/src/main/scala/org/apache/spark/sql/streaming/connector/s3/RocksDB.scala
+++ b/src/main/scala/org/apache/spark/sql/streaming/connector/s3/RocksDB.scala
@@ -160,7 +160,7 @@ class RocksDB(
   def remove(key: Array[Byte]): Array[Byte] = {
     val value = writeBatch.getFromBatchAndDB(db, readOptions, key)
     if (value != null) {
-      writeBatch.remove(key)
+      writeBatch.delete(key)
       numKeysOnWritingVersion -= 1
     }
     value


### PR DESCRIPTION
There is a known issue that seems to be related with the amount of messages on the queue, and when the service has processed all of them and the byte array is empty it uses a depreciated method that throws out an exception, I've upgraded the method to delete and see how it works.